### PR TITLE
Wave 3 fixes: scheduling, AI identity preservation, dashboard staleness, gaming cards

### DIFF
--- a/client/src/pages/CreatePage.tsx
+++ b/client/src/pages/CreatePage.tsx
@@ -429,7 +429,7 @@ export default function CreatePage() {
             songPollingRef.current.interval = null;
           }
           toast({ title: "Success", description: "Your song is ready!" });
-          queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+          queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
         } else if (updatedSong.status === 'failed' && !songPollingRef.current.toastShown) {
           console.log('[SongPoll] Song failed! Updating state...');
           songPollingRef.current.toastShown = true;
@@ -563,7 +563,7 @@ export default function CreatePage() {
       return await res.json() as Creation & { portraitVariations?: string[] };
     },
     onSuccess: (data: Creation & { portraitVariations?: string[] }) => {
-      queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
       setCreatedCard(data);
       
       // Capture portrait variations if available
@@ -747,7 +747,7 @@ export default function CreatePage() {
 
       const { creation } = await res.json();
       setCreatedPortrait(creation);
-      queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
       toast({ title: "Portrait created!", description: "Your family portrait is ready" });
     } catch (error: any) {
       toast({ title: "Error", description: error.message || "Failed to generate portrait", variant: "destructive" });
@@ -1751,7 +1751,7 @@ export default function CreatePage() {
       const res = await apiRequest("POST", "/api/generate/card", cardData);
       const newCard = await res.json() as Creation & { portraitVariations?: string[] };
       
-      queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
       setCreatedCard(newCard);
       
       // Capture portrait variations if available
@@ -1799,7 +1799,7 @@ export default function CreatePage() {
       return await res.json() as Creation;
     },
     onSuccess: (data: Creation) => {
-      queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
       setCreatedAnimation(data);
       toast({ title: "Success", description: "Your animation has been created!" });
     },
@@ -1896,7 +1896,7 @@ export default function CreatePage() {
       return await res.json() as Creation;
     },
     onSuccess: (data: Creation) => {
-      queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
       setCreatedSong(data);
       setLyricsPreview(null);
       setSongGenerationTime(0);
@@ -1995,7 +1995,7 @@ export default function CreatePage() {
       return await res.json() as Creation;
     },
     onSuccess: (data: Creation) => {
-      queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
       setCreatedSong(data);
       setPendingSongData(null);
       setSongGenerationTime(0);
@@ -2690,12 +2690,14 @@ export default function CreatePage() {
                               size="sm"
                               onClick={async () => {
                                 try {
-                                  await apiRequest("PATCH", `/api/creations/${createdCard.id}`, {
+                                  const res = await apiRequest("PATCH", `/api/creations/${createdCard.id}`, {
                                     content: editedCardMessage
                                   });
-                                  setCreatedCard({ ...createdCard, content: editedCardMessage });
-                                  await queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
-                                  await queryClient.refetchQueries({ queryKey: ['/api/creations'] });
+                                  const updated = await res.json();
+                                  setCreatedCard({ ...createdCard, ...updated });
+                                  // refetchType 'all' forces the inactive dashboard query to refetch;
+                                  // the default ('active') leaves it stale forever under staleTime: Infinity
+                                  queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
                                   setIsEditingCardMessage(false);
                                   toast({ title: "Saved!", description: "Message updated" });
                                 } catch {
@@ -2751,7 +2753,7 @@ export default function CreatePage() {
                                 });
                                 const data = await res.json();
                                 setCreatedCard({ ...createdCard, content: data.message });
-                                queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+                                queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
                                 toast({ title: "Regenerated!", description: "New message created" });
                               } catch {
                                 toast({ title: "Error", description: "Failed to regenerate message", variant: "destructive" });
@@ -2841,7 +2843,7 @@ export default function CreatePage() {
                                 imageUrl: selectedUrl
                               });
                               setCreatedCard({ ...createdCard, imageUrl: selectedUrl });
-                              queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+                              queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
                               toast({ title: "Saved!", description: `Variation ${selectedVariationIndex + 1} is now your card's cover image.` });
                             } catch {
                               toast({ title: "Error", description: "Failed to save selection", variant: "destructive" });
@@ -6631,7 +6633,7 @@ export default function CreatePage() {
                                 const selectedUrl = portraitVariations[selectedVariationIndex];
                                 await apiRequest("PATCH", `/api/creations/${createdCard.id}`, { imageUrl: selectedUrl });
                                 setCreatedCard({ ...createdCard, imageUrl: selectedUrl });
-                                queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+                                queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
                                 toast({ title: "Saved!", description: `Variation ${selectedVariationIndex + 1} is now your card's cover image.` });
                               }} data-testid="button-save-business-variation">
                                 Save This Variation
@@ -8192,7 +8194,7 @@ export default function CreatePage() {
                                 const selectedUrl = portraitVariations[selectedVariationIndex];
                                 await apiRequest("PATCH", `/api/creations/${createdCard.id}`, { imageUrl: selectedUrl });
                                 setCreatedCard({ ...createdCard, imageUrl: selectedUrl });
-                                queryClient.invalidateQueries({ queryKey: ['/api/creations'] });
+                                queryClient.invalidateQueries({ queryKey: ['/api/creations'], refetchType: 'all' });
                                 toast({ title: "Saved!", description: `Variation ${selectedVariationIndex + 1} is now your card's cover image.` });
                               }} data-testid="button-save-education-variation">
                                 Save This Variation

--- a/client/src/pages/RealDashboard.tsx
+++ b/client/src/pages/RealDashboard.tsx
@@ -1354,7 +1354,7 @@ export default function RealDashboard() {
                     <FormControl>
                       <Input
                         type="datetime-local"
-                        min={new Date(Date.now() + 60000).toISOString().slice(0, 16)}
+                        min={new Date(Date.now() + 60000 - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16)}
                         {...field}
                         data-testid="input-schedule-datetime"
                       />

--- a/client/src/pages/RealDashboard.tsx
+++ b/client/src/pages/RealDashboard.tsx
@@ -414,9 +414,13 @@ export default function RealDashboard() {
 
   const onScheduleSubmit = (data: z.infer<typeof scheduleFormSchema>) => {
     if (!schedulingCreation) return;
+    // datetime-local gives a local-time string with no timezone (e.g. "2026-06-15T14:30").
+    // new Date() parses that as local time, then toISOString() converts to UTC ISO so the
+    // server stores the correct moment regardless of server timezone (UTC on Replit).
+    const scheduledAtUtc = new Date(data.scheduledAt).toISOString();
     scheduleMutation.mutate({
       creationId: schedulingCreation.id,
-      scheduledAt: data.scheduledAt,
+      scheduledAt: scheduledAtUtc,
       recipientEmail: data.recipientEmail,
       recipientPhone: data.recipientPhone,
     });
@@ -1348,9 +1352,10 @@ export default function RealDashboard() {
                   <FormItem>
                     <FormLabel>Date & Time</FormLabel>
                     <FormControl>
-                      <Input 
-                        type="datetime-local" 
-                        {...field} 
+                      <Input
+                        type="datetime-local"
+                        min={new Date(Date.now() + 60000).toISOString().slice(0, 16)}
+                        {...field}
                         data-testid="input-schedule-datetime"
                       />
                     </FormControl>

--- a/server/nanoBananaService.ts
+++ b/server/nanoBananaService.ts
@@ -834,6 +834,10 @@ export async function generateFestiveTransform(params: {
   if (scene === 'blast-from-past' && blastFromPastSceneOverrides[style]) {
     // For blast-from-past, the style defines the scene
     sceneDesc = blastFromPastSceneOverrides[style];
+  } else if (scene === 'gaming' && sceneDescriptions[style]) {
+    // Gaming is a parent category in Festive Transform; the selected style
+    // carries the actual game scene. Do not fall back to Christmas here.
+    sceneDesc = sceneDescriptions[style];
   } else {
     sceneDesc = sceneDescriptions[scene] || sceneDescriptions['christmas'];
   }

--- a/server/nanoBananaService.ts
+++ b/server/nanoBananaService.ts
@@ -1022,7 +1022,16 @@ export async function generateYearbookHeadshot(params: {
   } else if (removeBraces) {
     removalInstr = ' Remove any dental braces from the person, giving them a natural smile.';
   }
-  
+
+  // Preserve features that were NOT requested to change — without this the model
+  // "beautifies" by default (auto-removing braces, restyling hair)
+  const preserveParts: string[] = [];
+  if (!removeBraces) {
+    preserveParts.push('dental braces (if visible) must remain exactly as they appear in the original photo - do not remove or alter them');
+  }
+  preserveParts.push("the person's exact original hairstyle, hair length, hair color, and hair texture - do not restyle, trim, straighten, or change their hair in any way");
+  const preserveInstr = ` Preserve unchanged: ${preserveParts.join('; ')}.`;
+
   const prompt = `Transform this photo into a professional yearbook headshot portrait. This must be a COMPLETE TRANSFORMATION — not just a background swap.
 
 BACKGROUND: ${bgDesc}.
@@ -1034,7 +1043,7 @@ CRITICAL REQUIREMENTS:
 - CHANGE their clothing to the described professional attire (do NOT keep their original clothes, hat, or accessories).
 - Remove any hats, caps, or head coverings — show their natural hair.
 - Frame as a head-and-shoulders portrait, centered, cropped from mid-chest up.
-- Apply professional portrait retouching: smooth skin, even lighting, polished yearbook-ready appearance.${removalInstr}
+- Apply only light, natural professional lighting and color correction - do NOT alter facial structure, teeth, dental appliances, or hairstyle.${removalInstr}${preserveInstr}
 - Professional school portrait photography quality, sharp focus on face, slight soft-focus on shoulders.
 - Photorealistic, high quality result suitable for an official yearbook or school directory.`;
 

--- a/server/openaiService.ts
+++ b/server/openaiService.ts
@@ -794,7 +794,13 @@ ${photoInstruction}
 
 ${params.message ? `Card message context: "${params.message}"` : ''}
 
-IMPORTANT: This must look like an authentic game UI screen/card that someone would see in the actual game. Make it professional, exciting, and visually stunning. The design should feel like it belongs in the actual game. Include all text elements clearly and legibly. Use vibrant colors and dramatic lighting. The overall composition should be a greeting card that any gamer would love to receive.`;
+IMPORTANT: This must look like an authentic game UI screen/card that someone would see in the actual game. Make it professional, exciting, and visually stunning. The design should feel like it belongs in the actual game. Include all text elements clearly and legibly. Use vibrant colors and dramatic lighting. The overall composition should be a greeting card that any gamer would love to receive.
+
+COMPOSITION SAFETY:
+- Keep every name, title, rating, rank, team, and stat fully inside the image boundaries.
+- Leave generous safe margins around the top, bottom, left, and right edges so no text, hands, shoes, heads, or stats are cropped.
+- If the requested text is long, reduce text size or stack fields instead of letting anything run off-canvas.
+- Show the full card/screen from top to bottom, including all stat rows and labels.`;
 
   console.log(`[GamingCard] Generating ${params.style} style gaming card for ${params.recipientName}${params.photoUrl ? ' (with photo)' : ''}`);
   console.log(`[GamingCard] Prompt preview: ${prompt.substring(0, 300)}...`);

--- a/server/openaiService.ts
+++ b/server/openaiService.ts
@@ -1283,7 +1283,7 @@ export function buildFamilyPortraitPrompt(params: FamilyPortraitParams): string 
     'achievement-class': 'honor class achievement setting with gold star decorations, achievement banners, recognition ribbons, proud moment celebration, excellence atmosphere',
     'school-identity': 'school-branded setting with school colors prominently displayed, school crest or mascot visible, institutional pride, academic tradition atmosphere',
     'fun-friendly': 'bright fun elementary classroom with colorful decorations, friendly shapes on walls, rainbow elements, happy learning atmosphere, child-friendly environment',
-    'minimal-portrait': 'clean minimal school portrait studio with simple white or soft gray backdrop, distraction-free, professional neutral lighting, gallery-ready quality',
+    'minimal-portrait': 'a tasteful, minimal school portrait setting featuring a simple painted studio backdrop in soft white or gray tones, gentle ambient classroom light, a few understated decor accents (a small plant, a framed school crest on the wall), clean and uncluttered composition',
     // Gaming scenes and styles
     'gaming-moments': 'an epic gaming moment scene with action and excitement, dramatic lighting, game controller elements, vibrant neon glow, competitive energy, esports atmosphere',
     'esports-celebration': 'an electrifying esports celebration scene with championship stage, LED screens, confetti, trophy, team victory moment, professional gaming arena, dramatic spotlights',
@@ -1357,6 +1357,16 @@ export function buildFamilyPortraitPrompt(params: FamilyPortraitParams): string 
     'oil-painting': 'classic oil painting style with rich textures and warm tones',
     'digital-art': 'modern digital art style with clean lines and vivid colors',
     'vintage': 'nostalgic vintage photograph style with warm sepia tones',
+    // Minimal Portrait (class portrait) styles — without these keys every style
+    // silently fell back to 'studio-photo' and rendered identically
+    'clean-white': 'crisp clean white studio backdrop with soft even lighting',
+    'soft-gray': 'soft neutral gray studio backdrop with gentle diffused lighting',
+    'natural-tones': 'warm natural-toned backdrop with soft window-style lighting',
+    'simple-focus': 'simple uncluttered composition with sharp focus on the group and a softly blurred backdrop',
+    'calm-composition': 'calm, balanced composition with gentle symmetrical arrangement and relaxed lighting',
+    'distraction-free': 'distraction-free backdrop with minimal elements, soft directional lighting',
+    'professional-neutral': 'professional neutral-toned studio setting with formal, even lighting',
+    'gallery-ready': 'polished, exhibition-quality portrait lighting and framing suitable for display',
   };
 
   // Determine the actual scene description
@@ -1429,7 +1439,12 @@ High quality, photorealistic result with detailed background, professional light
 Suitable for printing and framing.`;
 
   if (keepOutfits) {
-    prompt += `\n- Keep each person's original clothing and outfits from their source photos`;
+    prompt += `
+
+ORIGINAL CLOTHING - MANDATORY:
+- Do NOT change, restyle, or replace anyone's clothing - this is a strict requirement.
+- For each person, reproduce their exact original outfit from their reference photo: same garments, same colors, same patterns, same style (e.g., if they are wearing a plain t-shirt, keep it a plain t-shirt - do not add prints, florals, or different garments).
+- Only the background/scene, lighting, and overall composition should change - clothing must remain identical to the source photo.`;
   } else {
     // Scene-specific outfit recommendations
     const outfitSuggestions: Record<string, string> = {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2804,7 +2804,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
       
       const { scheduledAt, recipientEmail, recipientPhone } = schema.parse(req.body);
-      
+
+      // Reject past-dated schedules. Client sends UTC ISO string; compare directly to now.
+      const scheduledDate = new Date(scheduledAt);
+      if (isNaN(scheduledDate.getTime())) {
+        return res.status(400).json({ message: "Invalid date format" });
+      }
+      if (scheduledDate <= new Date()) {
+        return res.status(400).json({ message: "Scheduled time must be in the future" });
+      }
+
       // Verify the creation belongs to this user
       const creation = await storage.getCreationById(creationId);
       if (!creation) {


### PR DESCRIPTION
Six reviewed fixes, transported from the HBS-Dojo review process (originally reviewed in HInsights/HBS-Dojo PRs #3, #41, #42, #43) and verified byte-for-byte against that lineage. The base of this branch is the exact Replit production history ("Published your App"), so these commits apply to prod cleanly.

## Commits → issues

| Commit | Fix | Issues (this repo) |
|---|---|---|
| Fix #59: convert datetime-local to UTC ISO | Scheduled deliveries fired at the wrong time (local-time string sent raw); converts to UTC before the API call and adds past-date guards on client + server | Addresses #59 |
| Fix #59: compute datetime-local min in local time | The datetime picker's min attribute used UTC, blocking valid near-future times for users behind UTC | Addresses #59 |
| Strengthen AI identity preservation | Yearbook headshots auto-removed braces / restyled hair; Minimal Portrait styles all silently fell back to one look (8 missing style keys); keep-outfits instruction made mandatory | Addresses #32, #56, #57 |
| Dashboard never refetches after card create/edit | All 12 /api/creations invalidation sites now use refetchType: 'all' so the dashboard refreshes even while unmounted | Addresses #29 |
| Fix festive gaming scene fallback | Gaming styles in Festive Transform wrongly fell back to the Christmas scene | Addresses #42, #43 |
| Add safe margins to gaming card prompts | Names/stats/titles were getting cropped at card edges | Addresses #44, #50, #54 |

## Verification done
- All 6 apply cleanly in sequence on the exact prod snapshot (git am, zero conflicts)
- Patched result is byte-identical to the reviewed HBS-Dojo main on all 5 touched files
- npm run check on the patched tree: only the 3 known pre-existing errors, zero new
- Full history scanned for secrets before publishing: none (all credentials are env vars)

## Merge protocol
Do not merge until the fixes are deployed to Replit and pass the retest checklist — "Addresses" (not "Fixes") is used above deliberately so issues don't auto-close before verification.
